### PR TITLE
左右のメニュー崩れの修正とBaseの掃除

### DIFF
--- a/src/components/Base.tsx
+++ b/src/components/Base.tsx
@@ -1,12 +1,5 @@
 import type { ReactNode } from "react";
 
-import ExternalLinkIcon from "./ExternalLinkIcon";
-import { LinkButton } from "./LinkButon";
-import { Card } from "./ui/card";
-
-import LinkMenu from "@/components/LinkMenu";
-import SpMenu from "@/components/SpMenu";
-
 type BaseProps = {
     children?: ReactNode
 }
@@ -14,28 +7,17 @@ type BaseProps = {
 export default function Base({ children }: BaseProps) {
   return (
     <>
-      <div className="lg:flex items-center fixed top-0 left-0 hidden md:block md:w-[calc((100%_-_360px)/4*3)] lg:w-[calc((100%_-_768px)/2)] h-dvh bg-gradient-to-b from-[rgba(66,102,245,0.5)] to-[rgba(245,66,182,0.5)]">
+      <div className="lg:flex items-center fixed top-0 left-0 hidden md:block md:w-[calc((100%_-_360px)/4*3)] lg:w-[calc((100%_-_768px)/2)] h-dvh bg-ivory">
         {/* 左側エリア */}
-        <Card className="flex items-center justify-center mx-auto max-w-48 min-w-44 rounded-md bg-slate-50">
-          <LinkMenu className="py-8" textClassName="text-[#2a0252]"/>
-        </Card>
       </div>
-      <div className="w-full max-w-[500px] md:w-[360px] md:max-w-full lg:w-[768px] h-dvh mx-auto place-items-center">
+      <div className="w-full max-w-[500px] md:w-[360px] md:max-w-full lg:w-[768px] md:ml-[calc((100%_-_360px)/4*3)] lg:ml-auto h-dvh mx-auto place-items-center">
         {/* ここにSP用のタグとかを書いていく */}
-        <SpMenu menu={<LinkMenu />}/>
-        <div className="bg-gradient-to-b from-white via-white to-[rgba(0,0,0,0.2)]">
+        <div className="bg-ivory">
           {children}
         </div>
       </div>
-      <div className="lg:flex items-center fixed top-0 right-0 hidden md:block md:w-[calc((100%_-_360px)/4*1)] lg:w-[calc((100%_-_768px)/2)] h-dvh bg-gradient-to-b from-[rgba(66,102,245,0.5)] to-[rgba(245,66,182,0.5)]">
-        <Card className="flex items-center justify-center mx-auto max-w-80 min-w-60 py-4 rounded-md bg-slate-50">
-          <LinkButton href={{
-            host: "fortee.jp/",
-            pathname: "/frontend-conf-hokkaido-2024/sponsor/form"
-          }}>
-            <span className="text-[#2a0252] flex">スポンサー募集中!!(~5/30)<ExternalLinkIcon /></span>
-          </LinkButton>
-        </Card>
+      <div className="lg:flex items-center fixed top-0 right-0 hidden md:block md:w-[calc((100%_-_360px)/4*1)] lg:w-[calc((100%_-_768px)/2)] h-dvh bg-ivory">
+        {/* 右側エリア */}
       </div>
     </>
   );


### PR DESCRIPTION
## issue番号
<!-- "#{issue番号}"と書けば勝手にリンクしてくれます -->
<!-- "close #{issue番号}"と書けばPRがマージされると該当issueをクローズしてくれます -->

close #59

## やったこと
- 上書きされてしまったコミットと同様の修正 https://github.com/frontend-conference-hokkaido-2024/landing-page-2024/commit/637818eeb1bc80e12cb2f0cfc4f53278ee3a748f
- メニューなどの余計なものを削除
- 左右の背景色を`ivory`に変更(暫定対応)

## (あえて)やらないこと
<!-- 意図的に対応から外したことがあれば -->


## その他
<!-- 動作確認の注意点や懸念点などがあれば -->
